### PR TITLE
[ADD SCRIPT] set env for Amazon EMR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ read README.md in child dir for each environment.
 
 python with apache-spark for Mac.
 apache-spark ver. is 2.0.*
+
+### pyspark_emr
+
+python with apach-spark for Amazon Elastic Map Reduce.
+there is no difference on script between mac and EMR.

--- a/pyspark_emr/env.sh
+++ b/pyspark_emr/env.sh
@@ -1,0 +1,2 @@
+export SPARK_HOME=/usr/lib/spark
+export PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/build:`ls $SPARK_HOME/python/lib/py4j-0*.zip | xargs -n 1`


### PR DESCRIPTION
env.sh set environment variables

- $SPARK_HOME (fit in Aamzon Linux on EMR)
- $PYTHON_PATH (same as on OS X)